### PR TITLE
Improve chart option field docs

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -95,7 +95,7 @@ func mergeFontStyles(primary FontStyle, defaultFs ...FontStyle) FontStyle {
 
 // OffsetInt provides an ability to configure a shift from the top or left alignments.
 type OffsetInt struct {
-	// Left indicates a vertical spacing adjustment from the top.
+	// Top indicates a vertical spacing adjustment from the top.
 	Top int
 	// Left indicates a horizontal spacing adjustment from the left.
 	Left int

--- a/bar_chart.go
+++ b/bar_chart.go
@@ -41,16 +41,16 @@ func NewBarChartOptionWithSeries(sl BarSeriesList) BarChartOption {
 type BarChartOption struct {
 	// Theme specifies the colors used for the bar chart.
 	Theme ColorPalette
-	// Padding specifies the padding of bar chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// Deprecated: Font is deprecated, instead the font needs to be set on the SeriesLabel, or other specific elements.
 	Font *truetype.Font
 	// SeriesList provides the data population for the chart, typically constructed using NewSeriesListBar.
 	SeriesList BarSeriesList
-	// StackSeries if set to *true a single bar with the colored series stacked together will be rendered.
-	// This feature will result in some options being ignored, including BarMargin and SeriesLabelPosition.
-	// MarkLine is also interpreted differently, only the first Series will have the MarkLine rendered (as it's the
-	// base bar, other bars are influenced by prior values). StackSeries will only apply to the first YAxis (index 0).
+	// StackSeries, if true, renders the series stacked within one bar. This causes
+	// some options, including BarMargin and SeriesLabelPosition, to be ignored.
+	// MarkLine only renders for the first series and stacking only applies to the
+	// first YAxis (index 0).
 	StackSeries *bool
 	// SeriesLabelPosition specifies the position of the label for the series. Currently supported values are
 	// "top" or "bottom".
@@ -67,7 +67,7 @@ type BarChartOption struct {
 	BarWidth int
 	// BarMargin specifies the margin between bars grouped together. BarWidth takes priority over the margin.
 	BarMargin *float64
-	// RoundedBarCaps set to *true to produce a bar graph where the bars have rounded tops.
+	// RoundedBarCaps, if true, draws bars with rounded top corners.
 	RoundedBarCaps *bool
 	// ValueFormatter defines how float values should be rendered to strings, notably for numeric axis labels.
 	ValueFormatter ValueFormatter

--- a/chart_option.go
+++ b/chart_option.go
@@ -97,7 +97,7 @@ func FontOptionFunc(font *truetype.Font) OptionFunc {
 	}
 }
 
-// ThemeNameOptionFunc set them of chart by name.
+// ThemeNameOptionFunc sets the theme of the chart by name.
 func ThemeNameOptionFunc(theme string) OptionFunc {
 	return func(opt *ChartOption) {
 		opt.Theme = GetTheme(theme)

--- a/doughnut_chart.go
+++ b/doughnut_chart.go
@@ -26,7 +26,7 @@ func NewDoughnutChartOptionWithData(data []float64) DoughnutChartOption {
 type DoughnutChartOption struct {
 	// Theme specifies the colors used for the doughnut chart.
 	Theme ColorPalette
-	// Padding specifies the padding of doughnut chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// SeriesList provides the data population for the chart, typically constructed using NewSeriesListDoughnut.
 	SeriesList DoughnutSeriesList
@@ -34,9 +34,10 @@ type DoughnutChartOption struct {
 	Title TitleOption
 	// Legend are options for the data legend.
 	Legend LegendOption
-	// RadiusRing default outer radius for the ring e.g.: 40%, default is "40%"
+	// RadiusRing sets the outer radius of the ring, for example "40%".
+	// Default is "40%".
 	RadiusRing string
-	// RadiusCenter is the radius for the center hold of the doughnut. Must be smaller than RadiusRing.
+	// RadiusCenter is the radius for the center hole of the doughnut and must be smaller than RadiusRing.
 	RadiusCenter string
 	// CenterValues specifies what should be rendered in the center of the doughnut,
 	// current options are "none" (default), "labels", "sum".

--- a/funnel_chart.go
+++ b/funnel_chart.go
@@ -33,7 +33,7 @@ func NewFunnelChartOptionWithData(data []float64) FunnelChartOption {
 type FunnelChartOption struct {
 	// Theme specifies the colors used for the chart.
 	Theme ColorPalette
-	// Padding specifies the padding of funnel chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// Deprecated: Font is deprecated, instead the font needs to be set on the SeriesLabel, or other specific elements.
 	Font *truetype.Font

--- a/horizontal_bar_chart.go
+++ b/horizontal_bar_chart.go
@@ -28,16 +28,15 @@ func NewHorizontalBarChartOptionWithData(data [][]float64) HorizontalBarChartOpt
 type HorizontalBarChartOption struct {
 	// Theme specifies the colors used for the chart.
 	Theme ColorPalette
-	// Padding specifies the padding of bar chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// Deprecated: Font is deprecated, instead the font needs to be set on the SeriesLabel, or other specific elements.
 	Font *truetype.Font
 	// SeriesList provides the data population for the chart, typically constructed using NewSeriesListHorizontalBar.
 	SeriesList HorizontalBarSeriesList
-	// StackSeries if set to *true a single bar with the colored series stacked together will be rendered.
-	// This feature will result in some options being ignored, including BarMargin and SeriesLabelPosition.
-	// MarkLine is also interpreted differently, only the first Series will have the MarkLine rendered (as it's the
-	// base bar, other bars are influenced by prior values).
+	// StackSeries, if true, renders the series stacked within one bar. This
+	// causes some options, including BarMargin and SeriesLabelPosition, to be
+	// ignored. MarkLine only renders for the first series.
 	StackSeries *bool
 	// SeriesLabelPosition specifies the position of the label for the series. Currently supported values are
 	// "left" or "right".

--- a/line_chart.go
+++ b/line_chart.go
@@ -14,7 +14,7 @@ type lineChart struct {
 	opt *LineChartOption
 }
 
-// newLineChart returns a line chart render
+// newLineChart returns a line chart renderer.
 func newLineChart(p *Painter, opt LineChartOption) *lineChart {
 	return &lineChart{
 		p:   p,
@@ -46,18 +46,16 @@ func NewLineChartOptionWithSeries(sl LineSeriesList) LineChartOption {
 type LineChartOption struct {
 	// Theme specifies the colors used for the line chart.
 	Theme ColorPalette
-	// Padding specifies the padding of line chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// Deprecated: Font is deprecated, instead the font needs to be set on the SeriesLabel, or other specific elements.
 	Font *truetype.Font
 	// SeriesList provides the data population for the chart, typically constructed using NewSeriesListLine.
 	SeriesList LineSeriesList
-	// StackSeries if set to *true the lines will be layered over each other, with the last series value representing
-	// the sum of all the values. Enabling this will also enable FillArea (which until v0.5 can't be disabled).
-	// Some options will be ignored when StackedSeries is enabled, this includes StrokeSmoothingTension.
-	// MarkLine is also interpreted differently, only the first Series will have the MarkLine rendered (as it's the
-	// base bar, other bars are influenced by prior values). Additionally only the 0 index y-axis is stacked,
-	// allowing a non-stacked line to also be included on y-axis 1.
+	// StackSeries, if true, layers each series so the last represents the
+	// cumulative sum. This forces FillArea and ignores options like
+	// StrokeSmoothingTension. MarkLine only renders for the first series, and
+	// only the 0 index y-axis is stacked so another line can use the second axis.
 	StackSeries *bool
 	// XAxis are options for the x-axis.
 	XAxis XAxisOption

--- a/pie_chart.go
+++ b/pie_chart.go
@@ -31,7 +31,7 @@ func NewPieChartOptionWithData(data []float64) PieChartOption {
 type PieChartOption struct {
 	// Theme specifies the colors used for the pie chart.
 	Theme ColorPalette
-	// Padding specifies the padding of pie chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// Deprecated: Font is deprecated, instead the font needs to be set on the SeriesLabel, or other specific elements.
 	Font *truetype.Font
@@ -41,7 +41,8 @@ type PieChartOption struct {
 	Title TitleOption
 	// Legend are options for the data legend.
 	Legend LegendOption
-	// Radius default radius for pie e.g.: 40%, default is "40%"
+	// Radius sets the default pie radius, for example "40%".
+	// Default is "40%".
 	Radius string
 	// SegmentGap provides a gap between each pie slice.
 	SegmentGap float64

--- a/radar_chart.go
+++ b/radar_chart.go
@@ -39,9 +39,9 @@ func NewRadarChartOptionWithData(data [][]float64, names []string, values []floa
 
 // RadarChartOption defines the options for rendering a radar chart. Render the chart using Painter.RadarChart.
 type RadarChartOption struct {
-	// Theme specifies the colors used for the pie chart.
+	// Theme specifies the colors used for the radar chart.
 	Theme ColorPalette
-	// Padding specifies the padding of pie chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// Font is the font used to render the chart.
 	Font *truetype.Font
@@ -53,7 +53,8 @@ type RadarChartOption struct {
 	Legend LegendOption
 	// RadarIndicators provides the radar indicator list.
 	RadarIndicators []RadarIndicator
-	// Radius for radar e.g.: 40%, default is "40%"
+	// Radius sets the chart radius, for example "40%".
+	// Default is "40%".
 	Radius string
 	// ValueFormatter defines how float values should be rendered to strings, notably for series labels.
 	ValueFormatter ValueFormatter

--- a/scatter_chart.go
+++ b/scatter_chart.go
@@ -14,7 +14,7 @@ type scatterChart struct {
 	opt *ScatterChartOption
 }
 
-// newScatterChart returns a scatter chart render.
+// newScatterChart returns a scatter chart renderer.
 func newScatterChart(p *Painter, opt ScatterChartOption) *scatterChart {
 	return &scatterChart{
 		p:   p,
@@ -46,7 +46,7 @@ func NewScatterChartOptionWithSeries(sl ScatterSeriesList) ScatterChartOption {
 type ScatterChartOption struct {
 	// Theme specifies the colors used for the scatter chart.
 	Theme ColorPalette
-	// Padding specifies the padding of scatter chart.
+	// Padding specifies the padding around the chart.
 	Padding Box
 	// Deprecated: Font is deprecated, instead the font needs to be set on the SeriesLabel, or other specific elements.
 	Font *truetype.Font
@@ -61,8 +61,9 @@ type ScatterChartOption struct {
 	Title TitleOption
 	// Legend are options for the data legend.
 	Legend LegendOption
-	// Symbol specifies the default symbols to draw the data points with. Default is 'dot', additional options are:
-	// 'circle', 'dot', 'square', 'diamond'. This can also be set on a per-series level.
+	// Symbol specifies the default shape to draw each point with. The default
+	// is 'dot'. Valid options are 'circle', 'dot', 'square' and 'diamond'. This
+	// can also be set per-series.
 	Symbol Symbol
 	// SymbolSize specifies the size for each data point, default is 2.0.
 	SymbolSize float64

--- a/table.go
+++ b/table.go
@@ -66,7 +66,7 @@ type tableChart struct {
 	opt *TableChartOption
 }
 
-// newTableChart returns a table chart render.
+// newTableChart returns a table chart renderer.
 func newTableChart(p *Painter, opt TableChartOption) *tableChart {
 	return &tableChart{
 		p:   p,


### PR DESCRIPTION
## Summary
- mention default ring size in doughnut options
- note default pie radius
- clarify radar chart radius default
- fix per-series wording in scatter chart docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b80d6c8108329a9c646f0892c2ed6