### PR TITLE
Add matrix util tests

### DIFF
--- a/chartdraw/matrix/util_test.go
+++ b/chartdraw/matrix/util_test.go
@@ -1,0 +1,72 @@
+package matrix
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		values []int
+		expect int
+	}{
+		{"Empty", nil, math.MaxInt32},
+		{"Single", []int{5}, 5},
+		{"Mixed", []int{3, 1, 2}, 1},
+		{"Negative", []int{0, -2, 2}, -2},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, minInt(tc.values...))
+		})
+	}
+}
+
+func TestF64s(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		value  float64
+		expect string
+	}{
+		{"Zero", 0, "0"},
+		{"Positive", 1.23, "1.23"},
+		{"Integer", 3.0, "3"},
+		{"Negative", -0.5, "-0.5"},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, f64s(tc.value))
+		})
+	}
+}
+
+func TestRoundToEpsilon(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   float64
+		epsilon float64
+	}{
+		{"Zero", 0, 0},
+		{"Positive", 1.234, 0.1},
+		{"Negative", -2.5, 0.001},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
+			r := roundToEpsilon(tc.value, tc.epsilon)
+			assert.InDelta(t, tc.value, r, 0)
+		})
+	}
+}

--- a/line_chart_test.go
+++ b/line_chart_test.go
@@ -979,3 +979,17 @@ func TestLineChartError(t *testing.T) {
 		})
 	}
 }
+
+func TestBoundaryGapAxisPositions(t *testing.T) {
+	t.Parallel()
+
+	got := boundaryGapAxisPositions(10, false, 3)
+	assert.Equal(t, []int{0, 5, 10}, got)
+	assert.Equal(t, 0, got[0])
+	assert.Equal(t, 10, got[len(got)-1])
+
+	got = boundaryGapAxisPositions(10, true, 3)
+	assert.Equal(t, []int{1, 4, 8}, got)
+	assert.Equal(t, 1, got[0])
+	assert.Equal(t, 8, got[len(got)-1])
+}

--- a/series_test.go
+++ b/series_test.go
@@ -258,6 +258,21 @@ func TestSumSeriesValues(t *testing.T) {
 	}
 }
 
+func TestSumSeriesDataAndMaxCount(t *testing.T) {
+	t.Parallel()
+
+	seriesList := LineSeriesList{
+		{Values: []float64{1, 2}, YAxisIndex: 0},
+		{Values: []float64{3, 4, 5}, YAxisIndex: 1},
+		{Values: []float64{6}, YAxisIndex: 0},
+	}
+
+	assert.Equal(t, []float64{10, 6, 5}, sumSeriesData(seriesList, -1))
+	assert.Equal(t, []float64{7, 2, 0}, sumSeriesData(seriesList, 0))
+	assert.Equal(t, []float64{3, 4, 5}, sumSeriesData(seriesList, 1))
+	assert.Equal(t, 3, getSeriesMaxDataCount(seriesList))
+}
+
 func TestSeriesSummary(t *testing.T) {
 	t.Parallel()
 

--- a/trend_line_test.go
+++ b/trend_line_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,5 +99,66 @@ func TestTrendLine(t *testing.T) {
 			require.NoError(t, err)
 			assertEqualSVG(t, tt.result, data)
 		})
+	}
+}
+
+func TestLinearTrend(t *testing.T) {
+	t.Parallel()
+
+	input := []float64{2, 4, 6, 8}
+	expected := []float64{2, 4, 6, 8}
+
+	result, err := linearTrend(input)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
+	}
+}
+
+func TestCubicTrend(t *testing.T) {
+	t.Parallel()
+
+	input := []float64{0, 1, 8, 27}
+	expected := []float64{0, 1, 8, 27}
+
+	result, err := cubicTrend(input)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
+	}
+}
+
+func TestMovingAverageTrend(t *testing.T) {
+	t.Parallel()
+
+	input := []float64{1, 2, 3, 4, 5}
+	expected := []float64{1, 1.5, 2, 3, 4}
+
+	result, err := movingAverageTrend(input, 3)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
+	}
+}
+
+func TestSolveLinearSystem(t *testing.T) {
+	t.Parallel()
+
+	mat := [][]float64{
+		{0, 1, 0, 0, 2},
+		{1, 0, 0, 0, 1},
+		{0, 0, 1, 0, 3},
+		{0, 0, 0, 1, 4},
+	}
+	expected := []float64{1, 2, 3, 4}
+
+	result, err := solveLinearSystem(mat)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
 	}
 }


### PR DESCRIPTION
## Summary
- add `chartdraw/matrix/util_test.go`
- cover `minInt`, `f64s`, and `roundToEpsilon` with unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b884543c4832981856882e7d47336