### PR TITLE
test: unify newer tests

### DIFF
--- a/chartdraw/drawing/flattener_test.go
+++ b/chartdraw/drawing/flattener_test.go
@@ -75,3 +75,32 @@ func TestFlattenMultiMove(t *testing.T) {
 	assert.InDeltaSlice(t, expectX, rec.xs, 0.0001)
 	assert.InDeltaSlice(t, expectY, rec.ys, 0.0001)
 }
+
+func TestSegmentedPathPoints(t *testing.T) {
+	t.Parallel()
+
+	sp := &SegmentedPath{}
+	sp.MoveTo(0, 0)
+	sp.LineTo(1, 1)
+	sp.End()
+	assert.InDeltaSlice(t, []float64{0, 0, 1, 1}, sp.Points, 0.0001)
+
+	sp.MoveTo(2, 2)
+	sp.LineTo(3, 3)
+	sp.End()
+	expect := []float64{0, 0, 1, 1, 2, 2, 3, 3}
+	assert.InDeltaSlice(t, expect, sp.Points, 0.0001)
+}
+
+func TestSegmentedPathEnd(t *testing.T) {
+	t.Parallel()
+
+	sp := &SegmentedPath{}
+	sp.MoveTo(1, 1)
+	sp.LineTo(2, 2)
+
+	expect := append([]float64(nil), sp.Points...)
+	sp.End()
+
+	assert.InDeltaSlice(t, expect, sp.Points, 0.0001)
+}

--- a/chartdraw/drawing/flattener_test.go
+++ b/chartdraw/drawing/flattener_test.go
@@ -79,17 +79,21 @@ func TestFlattenMultiMove(t *testing.T) {
 func TestSegmentedPathPoints(t *testing.T) {
 	t.Parallel()
 
-	sp := &SegmentedPath{}
-	sp.MoveTo(0, 0)
-	sp.LineTo(1, 1)
-	sp.End()
-	assert.InDeltaSlice(t, []float64{0, 0, 1, 1}, sp.Points, 0.0001)
+	segments := []struct {
+		startX, startY float64
+		endX, endY     float64
+	}{
+		{0, 0, 1, 1},
+		{2, 2, 3, 3},
+	}
 
-	sp.MoveTo(2, 2)
-	sp.LineTo(3, 3)
-	sp.End()
-	expect := []float64{0, 0, 1, 1, 2, 2, 3, 3}
-	assert.InDeltaSlice(t, expect, sp.Points, 0.0001)
+	sp := &SegmentedPath{}
+	for _, seg := range segments {
+		sp.MoveTo(seg.startX, seg.startY)
+		sp.LineTo(seg.endX, seg.endY)
+		sp.End()
+	}
+	assert.InDeltaSlice(t, []float64{0, 0, 1, 1, 2, 2, 3, 3}, sp.Points, 0.0001)
 }
 
 func TestSegmentedPathEnd(t *testing.T) {

--- a/chartdraw/drawing/free_type_path_test.go
+++ b/chartdraw/drawing/free_type_path_test.go
@@ -1,0 +1,37 @@
+package drawing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/image/math/fixed"
+)
+
+type mockAdder struct {
+	starts []fixed.Point26_6
+	adds   []fixed.Point26_6
+}
+
+func (m *mockAdder) Start(p fixed.Point26_6)      { m.starts = append(m.starts, p) }
+func (m *mockAdder) Add1(p fixed.Point26_6)       { m.adds = append(m.adds, p) }
+func (m *mockAdder) Add2(b, c fixed.Point26_6)    {}
+func (m *mockAdder) Add3(b, c, d fixed.Point26_6) {}
+
+func TestFtLineBuilderMoveToLineTo(t *testing.T) {
+	t.Parallel()
+
+	ad := &mockAdder{}
+	ft := FtLineBuilder{Adder: ad}
+	ft.MoveTo(1, 2)
+	ft.LineTo(3, 4)
+	ft.End()
+
+	if assert.Len(t, ad.starts, 1) {
+		assert.Equal(t, fixed.Int26_6(64), ad.starts[0].X)
+		assert.Equal(t, fixed.Int26_6(128), ad.starts[0].Y)
+	}
+	if assert.Len(t, ad.adds, 1) {
+		assert.Equal(t, fixed.Int26_6(192), ad.adds[0].X)
+		assert.Equal(t, fixed.Int26_6(256), ad.adds[0].Y)
+	}
+}

--- a/chartdraw/drawing/raster_graphic_context_test.go
+++ b/chartdraw/drawing/raster_graphic_context_test.go
@@ -3,9 +3,14 @@ package drawing
 import (
 	"image"
 	"image/color"
+	"math"
 	"testing"
 
+	"github.com/go-analyze/charts/chartdraw/roboto"
+	"github.com/golang/freetype/truetype"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/image/math/fixed"
 )
 
 func TestRasterGraphicContextBasic(t *testing.T) {
@@ -94,4 +99,131 @@ func TestRasterStrokeAndFillStroke(t *testing.T) {
 	rgc.Stroke(p)
 	_, _, _, a = img2.At(1, 0).RGBA()
 	assert.Equal(t, uint32(0xffff), a)
+}
+
+func TestRasterFontFunctions(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 20, 20))
+	rgc := NewRasterGraphicContext(img)
+
+	f, err := truetype.Parse(roboto.Roboto)
+	require.NoError(t, err)
+	rgc.SetFont(f)
+	assert.Equal(t, f, rgc.GetFont())
+
+	rgc.SetFontSize(12)
+	assert.InDelta(t, 12.0, rgc.GetFontSize(), 0.0)
+
+	rgc.SetFontSize(8)
+	wSmall, err := rgc.CreateStringPath("A", 0, 0)
+	require.NoError(t, err)
+
+	rgc.SetFontSize(16)
+	wLarge, err := rgc.CreateStringPath("A", 0, 0)
+	require.NoError(t, err)
+	assert.Greater(t, wLarge, wSmall)
+}
+
+func TestRasterCreateStringPathAndBounds(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 50, 50))
+	rgc := NewRasterGraphicContext(img)
+	f, err := truetype.Parse(roboto.Roboto)
+	require.NoError(t, err)
+	rgc.SetFont(f)
+	rgc.SetFontSize(10)
+
+	idx := f.Index('A')
+	expected := fUnitsToFloat64(f.HMetric(fixed.Int26_6(rgc.current.Scale), idx).AdvanceWidth)
+	cursor, err := rgc.CreateStringPath("A", 0, 0)
+	require.NoError(t, err)
+	assert.InDelta(t, expected, cursor, 0.001)
+	assert.False(t, rgc.current.Path.IsEmpty())
+
+	left, top, right, bottom, err := rgc.GetStringBounds("A")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, cursor, right-left)
+
+	pbLeft, pbTop, pbRight, pbBottom := pathBounds(rgc.current.Path)
+	assert.InDelta(t, left, pbLeft, 0.001)
+	assert.InDelta(t, top, pbTop, 0.001)
+	assert.InDelta(t, right, pbRight, 0.001)
+	assert.InDelta(t, bottom, pbBottom, 0.001)
+}
+
+func TestRasterFillAndStrokeStringAt(t *testing.T) {
+	t.Parallel()
+
+	f, err := truetype.Parse(roboto.Roboto)
+	require.NoError(t, err)
+
+	img := image.NewRGBA(image.Rect(0, 0, 50, 50))
+	rgc := NewRasterGraphicContext(img)
+	rgc.SetFont(f)
+	rgc.SetFontSize(10)
+	rgc.SetFillColor(color.White)
+
+	left, top, right, bottom, err := rgc.GetStringBounds("A")
+	require.NoError(t, err)
+	x, y := 10.0, 30.0
+	_, err = rgc.FillStringAt("A", x, y)
+	require.NoError(t, err)
+
+	x1 := int(math.Floor(left + x))
+	y1 := int(math.Floor(top + y))
+	found := false
+	for yy := y1; yy < int(math.Ceil(bottom+y)) && !found; yy++ {
+		for xx := x1; xx < int(math.Ceil(right+x)) && !found; xx++ {
+			_, _, _, a := img.At(xx, yy).RGBA()
+			if a != 0 {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "filled text not drawn")
+
+	img2 := image.NewRGBA(image.Rect(0, 0, 50, 50))
+	rgc2 := NewRasterGraphicContext(img2)
+	rgc2.SetFont(f)
+	rgc2.SetFontSize(10)
+	rgc2.SetStrokeColor(color.White)
+
+	_, err = rgc2.StrokeStringAt("A", x, y)
+	require.NoError(t, err)
+	found = false
+	for yy := y1; yy < int(math.Ceil(bottom+y)) && !found; yy++ {
+		for xx := x1; xx < int(math.Ceil(right+x)) && !found; xx++ {
+			_, _, _, a := img2.At(xx, yy).RGBA()
+			if a != 0 {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "stroked text not drawn")
+}
+
+func pathBounds(p *Path) (left, top, right, bottom float64) {
+	if len(p.Points) == 0 {
+		return
+	}
+	left, top = p.Points[0], p.Points[1]
+	right, bottom = left, top
+	for i := 2; i < len(p.Points); i += 2 {
+		x, y := p.Points[i], p.Points[i+1]
+		if x < left {
+			left = x
+		}
+		if y < top {
+			top = y
+		}
+		if x > right {
+			right = x
+		}
+		if y > bottom {
+			bottom = y
+		}
+	}
+	return
 }

--- a/chartdraw/drawing/stack_graphic_context_test.go
+++ b/chartdraw/drawing/stack_graphic_context_test.go
@@ -4,7 +4,11 @@ import (
 	"math"
 	"testing"
 
+	"github.com/golang/freetype/truetype"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-analyze/charts/chartdraw/roboto"
 )
 
 func TestStackGraphicContextSaveRestore(t *testing.T) {
@@ -59,4 +63,104 @@ func TestStackMatrixTransform(t *testing.T) {
 	x, y := got.TransformPoint(0, 0)
 	assert.InDelta(t, 5.0, x, 0.0001)
 	assert.InDelta(t, 7.0, y, 0.0001)
+}
+
+func TestStackComposeMatrixTransform(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	gc.SetMatrixTransform(NewTranslationMatrix(5, 7))
+	gc.ComposeMatrixTransform(NewTranslationMatrix(3, 4))
+	got := gc.GetMatrixTransform()
+	x, y := got.TransformPoint(0, 0)
+	assert.InDelta(t, 8.0, x, 0.0001)
+	assert.InDelta(t, 11.0, y, 0.0001)
+}
+
+func TestStackLineDash(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	dash := []float64{1, 2, 3}
+	gc.SetLineDash(dash, 0.5)
+	assert.Equal(t, dash, gc.current.Dash)
+	assert.InDelta(t, 0.5, gc.current.DashOffset, 0.0001)
+}
+
+func TestStackFontRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	f, err := truetype.Parse(roboto.Roboto)
+	require.NoError(t, err)
+
+	gc := NewStackGraphicContext()
+	gc.SetFont(f)
+	gc.SetFontSize(13.0)
+	assert.Equal(t, f, gc.GetFont())
+	assert.InDelta(t, 13.0, gc.GetFontSize(), 0.0001)
+}
+
+func TestStackScale(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	before := gc.GetMatrixTransform()
+	gc.Scale(2, 3)
+	after := gc.GetMatrixTransform()
+
+	assert.False(t, before.Equals(after))
+	sx, sy := after.GetScaling()
+	assert.InDelta(t, 2.0, sx, 0.0001)
+	assert.InDelta(t, 3.0, sy, 0.0001)
+}
+
+func TestStackSetFillRule(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	gc.SetFillRule(FillRuleWinding)
+	assert.Equal(t, FillRuleWinding, gc.current.FillRule)
+	gc.SetFillRule(FillRuleEvenOdd)
+	assert.Equal(t, FillRuleEvenOdd, gc.current.FillRule)
+}
+
+func TestStackBeginPathIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	gc.MoveTo(1, 1)
+	gc.LineTo(2, 2)
+	require.False(t, gc.IsEmpty())
+	gc.BeginPath()
+	assert.True(t, gc.IsEmpty())
+	assert.Empty(t, gc.current.Path.Points)
+}
+
+func TestStackPathCurvesAndClose(t *testing.T) {
+	t.Parallel()
+
+	gc := NewStackGraphicContext()
+	gc.QuadCurveTo(1, 1, 2, 2)
+	gc.CubicCurveTo(3, 3, 4, 4, 5, 5)
+	gc.ArcTo(0, 0, 1, 1, 0, math.Pi/2)
+	gc.Close()
+
+	expComp := []PathComponent{
+		MoveToComponent,
+		QuadCurveToComponent,
+		CubicCurveToComponent,
+		LineToComponent,
+		ArcToComponent,
+		CloseComponent,
+	}
+	assert.Equal(t, expComp, gc.current.Path.Components)
+
+	expPts := []float64{
+		0, 0,
+		1, 1, 2, 2,
+		3, 3, 4, 4, 5, 5,
+		1, 0,
+		0, 0, 1, 1, 0, math.Pi / 2,
+	}
+	assert.InDeltaSlice(t, expPts, gc.current.Path.Points, 0.0001)
 }

--- a/chartdraw/drawing/util_test.go
+++ b/chartdraw/drawing/util_test.go
@@ -86,3 +86,20 @@ func TestPointToF64Point(t *testing.T) {
 	// Y is negated inside function
 	assert.InDelta(t, 1.0, y, 0.0001)
 }
+
+func TestAbsInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in, want int
+	}{
+		{5, 5},
+		{-5, 5},
+		{0, 0},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.want, absInt(tt.in))
+		})
+	}
+}

--- a/chartdraw/matrix/matrix_test.go
+++ b/chartdraw/matrix/matrix_test.go
@@ -236,6 +236,16 @@ func TestMatrixScaleRow(t *testing.T) {
 	assert.Equal(t, Vector([]float64{7, 8, 9}), m.Row(2))
 }
 
+func TestMatrixScaleAddRow(t *testing.T) {
+	t.Parallel()
+
+	m := NewFromArrays([][]float64{{1, 2, 3}, {4, 5, 6}})
+	m.scaleAddRow(1, 0, 2)
+
+	assert.Equal(t, Vector([]float64{1, 2, 3}), m.Row(0))
+	assert.Equal(t, Vector([]float64{6, 9, 12}), m.Row(1))
+}
+
 func TestMatrixCopy(t *testing.T) {
 	t.Parallel()
 
@@ -620,6 +630,21 @@ func TestMatrixEye(t *testing.T) {
 			} else {
 				assert.InDelta(t, float64(0), m.Get(r, c), 0)
 			}
+		}
+	}
+}
+
+func TestMatrixZero(t *testing.T) {
+	t.Parallel()
+
+	m := Zero(2, 3)
+	rows, cols := m.Size()
+	assert.Equal(t, 2, rows)
+	assert.Equal(t, 3, cols)
+
+	for r := 0; r < 2; r++ {
+		for c := 0; c < 3; c++ {
+			assert.Zero(t, m.Get(r, c))
 		}
 	}
 }

--- a/chartdraw/matrix/util_test.go
+++ b/chartdraw/matrix/util_test.go
@@ -1,0 +1,72 @@
+package matrix
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		values []int
+		expect int
+	}{
+		{"Empty", nil, math.MaxInt32},
+		{"Single", []int{5}, 5},
+		{"Mixed", []int{3, 1, 2}, 1},
+		{"Negative", []int{0, -2, 2}, -2},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, minInt(tc.values...))
+		})
+	}
+}
+
+func TestF64s(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		value  float64
+		expect string
+	}{
+		{"Zero", 0, "0"},
+		{"Positive", 1.23, "1.23"},
+		{"Integer", 3.0, "3"},
+		{"Negative", -0.5, "-0.5"},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, f64s(tc.value))
+		})
+	}
+}
+
+func TestRoundToEpsilon(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   float64
+		epsilon float64
+	}{
+		{"Zero", 0, 0},
+		{"Positive", 1.234, 0.1},
+		{"Negative", -2.5, 0.001},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i)+"-"+tc.name, func(t *testing.T) {
+			r := roundToEpsilon(tc.value, tc.epsilon)
+			assert.InDelta(t, tc.value, r, 0)
+		})
+	}
+}

--- a/chartdraw/min_max_series_test.go
+++ b/chartdraw/min_max_series_test.go
@@ -1,0 +1,45 @@
+package chartdraw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinSeriesEnsureMinValue(t *testing.T) {
+	t.Parallel()
+
+	vp := mockValuesProvider{
+		X: LinearRange(1.0, 5.0),
+		Y: []float64{4, 2, 5, 1, 3},
+	}
+
+	ms := &MinSeries{InnerSeries: vp}
+	ms.ensureMinValue()
+
+	if assert.NotNil(t, ms.minValue) {
+		assert.InDelta(t, 1.0, *ms.minValue, 0)
+	}
+
+	_, y := ms.GetValues(0)
+	assert.InDelta(t, 1.0, y, 0)
+}
+
+func TestMaxSeriesEnsureMaxValue(t *testing.T) {
+	t.Parallel()
+
+	vp := mockValuesProvider{
+		X: LinearRange(1.0, 5.0),
+		Y: []float64{4, 2, 5, 1, 3},
+	}
+
+	ms := &MaxSeries{InnerSeries: vp}
+	ms.ensureMaxValue()
+
+	if assert.NotNil(t, ms.maxValue) {
+		assert.InDelta(t, 5.0, *ms.maxValue, 0)
+	}
+
+	_, y := ms.GetValues(0)
+	assert.InDelta(t, 5.0, y, 0)
+}

--- a/chartdraw/polynomial_regression_series_test.go
+++ b/chartdraw/polynomial_regression_series_test.go
@@ -1,0 +1,32 @@
+package chartdraw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-analyze/charts/chartdraw/matrix"
+)
+
+func TestPolynomialRegressionSeries_GetValues(t *testing.T) {
+	t.Parallel()
+
+	xs := []float64{0, 1, 2, 3}
+	ys := []float64{5, 10, 19, 32}
+
+	series := ContinuousSeries{
+		XValues: xs,
+		YValues: ys,
+	}
+
+	prs := &PolynomialRegressionSeries{
+		InnerSeries: series,
+		Degree:      2,
+	}
+
+	for i, x := range xs {
+		_, y := prs.GetValues(i)
+		expect := 5 + 3*x + 2*x*x
+		assert.InDelta(t, expect, y, matrix.DefaultEpsilon)
+	}
+}

--- a/charts_test.go
+++ b/charts_test.go
@@ -1,0 +1,14 @@
+package charts
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNullValue(t *testing.T) {
+	t.Parallel()
+
+	assert.InDelta(t, math.MaxFloat64, GetNullValue(), 0.0)
+}

--- a/line_chart_test.go
+++ b/line_chart_test.go
@@ -983,13 +983,20 @@ func TestLineChartError(t *testing.T) {
 func TestBoundaryGapAxisPositions(t *testing.T) {
 	t.Parallel()
 
-	got := boundaryGapAxisPositions(10, false, 3)
-	assert.Equal(t, []int{0, 5, 10}, got)
-	assert.Equal(t, 0, got[0])
-	assert.Equal(t, 10, got[len(got)-1])
+	cases := []struct {
+		boundaryGap bool
+		expect      []int
+	}{
+		{false, []int{0, 5, 10}},
+		{true, []int{1, 4, 8}},
+	}
 
-	got = boundaryGapAxisPositions(10, true, 3)
-	assert.Equal(t, []int{1, 4, 8}, got)
-	assert.Equal(t, 1, got[0])
-	assert.Equal(t, 8, got[len(got)-1])
+	for i, tt := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got := boundaryGapAxisPositions(10, tt.boundaryGap, 3)
+			assert.Equal(t, tt.expect, got)
+			assert.Equal(t, tt.expect[0], got[0])
+			assert.Equal(t, tt.expect[len(tt.expect)-1], got[len(got)-1])
+		})
+	}
 }

--- a/line_chart_test.go
+++ b/line_chart_test.go
@@ -979,3 +979,17 @@ func TestLineChartError(t *testing.T) {
 		})
 	}
 }
+
+func TestBoundaryGapAxisPositions(t *testing.T) {
+	t.Parallel()
+
+	got := boundaryGapAxisPositions(10, false, 3)
+	assert.Equal(t, []int{0, 5, 10}, got)
+	assert.Equal(t, 0, got[0])
+	assert.Equal(t, 10, got[len(got)-1])
+
+	got = boundaryGapAxisPositions(10, true, 3)
+	assert.Equal(t, []int{1, 4, 8}, got)
+	assert.Equal(t, 1, got[0])
+	assert.Equal(t, 8, got[len(got)-1])
+}

--- a/series_test.go
+++ b/series_test.go
@@ -258,6 +258,21 @@ func TestSumSeriesValues(t *testing.T) {
 	}
 }
 
+func TestSumSeriesDataAndMaxCount(t *testing.T) {
+	t.Parallel()
+
+	seriesList := LineSeriesList{
+		{Values: []float64{1, 2}, YAxisIndex: 0},
+		{Values: []float64{3, 4, 5}, YAxisIndex: 1},
+		{Values: []float64{6}, YAxisIndex: 0},
+	}
+
+	assert.Equal(t, []float64{10, 6, 5}, sumSeriesData(seriesList, -1))
+	assert.Equal(t, []float64{7, 2, 0}, sumSeriesData(seriesList, 0))
+	assert.Equal(t, []float64{3, 4, 5}, sumSeriesData(seriesList, 1))
+	assert.Equal(t, 3, getSeriesMaxDataCount(seriesList))
+}
+
 func TestSeriesSummary(t *testing.T) {
 	t.Parallel()
 

--- a/trend_line_test.go
+++ b/trend_line_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,5 +99,66 @@ func TestTrendLine(t *testing.T) {
 			require.NoError(t, err)
 			assertEqualSVG(t, tt.result, data)
 		})
+	}
+}
+
+func TestLinearTrend(t *testing.T) {
+	t.Parallel()
+
+	input := []float64{2, 4, 6, 8}
+	expected := []float64{2, 4, 6, 8}
+
+	result, err := linearTrend(input)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
+	}
+}
+
+func TestCubicTrend(t *testing.T) {
+	t.Parallel()
+
+	input := []float64{0, 1, 8, 27}
+	expected := []float64{0, 1, 8, 27}
+
+	result, err := cubicTrend(input)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
+	}
+}
+
+func TestMovingAverageTrend(t *testing.T) {
+	t.Parallel()
+
+	input := []float64{1, 2, 3, 4, 5}
+	expected := []float64{1, 1.5, 2, 3, 4}
+
+	result, err := movingAverageTrend(input, 3)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
+	}
+}
+
+func TestSolveLinearSystem(t *testing.T) {
+	t.Parallel()
+
+	mat := [][]float64{
+		{0, 1, 0, 0, 2},
+		{1, 0, 0, 0, 1},
+		{0, 0, 1, 0, 3},
+		{0, 0, 0, 1, 4},
+	}
+	expected := []float64{1, 2, 3, 4}
+
+	result, err := solveLinearSystem(mat)
+	require.NoError(t, err)
+	require.Len(t, result, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], result[i], 1e-9)
 	}
 }


### PR DESCRIPTION
## Summary
- rewrite some recent tests to be table-driven
- keep `t.Parallel()` placement consistent across the suite

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b9574737c832988c5047867622e94