### PR TITLE
Add rendering tests

### DIFF
--- a/chartdraw/draw_test.go
+++ b/chartdraw/draw_test.go
@@ -1,0 +1,67 @@
+package chartdraw
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-analyze/charts/chartdraw/drawing"
+)
+
+type boundedTest struct{}
+
+func (boundedTest) Len() int { return 3 }
+func (boundedTest) GetBoundedValues(i int) (float64, float64, float64) {
+	return float64(i), float64(i + 1), float64(i)
+}
+
+func TestDrawBoundedAndHistogramSeries(t *testing.T) {
+	t.Parallel()
+
+	vr := SVG(60, 60).(*vectorRenderer)
+	style := Style{StrokeColor: drawing.ColorBlack, FillColor: drawing.ColorWhite}
+
+	Draw.BoundedSeries(vr, Box{Bottom: 50, Left: 0}, &ContinuousRange{Min: 0, Max: 2, Domain: 50}, &ContinuousRange{Min: 0, Max: 3, Domain: 50}, style, boundedTest{})
+	hist := HistogramSeries{InnerSeries: ContinuousSeries{XValues: LinearRange(0, 2), YValues: LinearRange(1, 3)}}
+	Draw.HistogramSeries(vr, Box{Bottom: 50, Left: 0}, &ContinuousRange{Min: 0, Max: 2, Domain: 50}, &ContinuousRange{Min: 0, Max: 3, Domain: 50}, style, hist)
+
+	buf := bytes.Buffer{}
+	require.NoError(t, vr.Save(&buf))
+	out := buf.String()
+	assert.Contains(t, out, "<path")
+}
+
+func TestDrawAnnotationAndText(t *testing.T) {
+	t.Parallel()
+
+	vr := SVG(80, 80).(*vectorRenderer)
+	style := Style{FillColor: drawing.ColorWhite, StrokeColor: drawing.ColorBlack, FontStyle: FontStyle{Font: GetDefaultFont(), FontSize: 10}}
+	Draw.Annotation(vr, style, 10, 10, "label")
+	Draw.Text(vr, "hello", 5, 5, style)
+	Draw.BoxRotated(vr, Box{Top: 1, Left: 1, Right: 10, Bottom: 10}, 45, style)
+	Draw.BoxCorners(vr, Box{Top: 1, Left: 1, Right: 5, Bottom: 5}.Corners(), style)
+
+	buf := bytes.Buffer{}
+	require.NoError(t, vr.Save(&buf))
+	out := buf.String()
+	assert.Contains(t, out, "label")
+	assert.Contains(t, out, "<path")
+}
+
+func TestDrawMeasureTextAndTextWithin(t *testing.T) {
+	t.Parallel()
+
+	vr := SVG(100, 50).(*vectorRenderer)
+	vr.SetFont(GetDefaultFont())
+	vr.SetFontSize(10)
+	box := Draw.MeasureText(vr, "abc", Style{FontStyle: FontStyle{Font: GetDefaultFont(), FontSize: 10}})
+	assert.NotZero(t, box.Width())
+
+	Draw.TextWithin(vr, "abc", Box{Top: 0, Left: 0, Right: 50, Bottom: 20}, Style{FontStyle: FontStyle{Font: GetDefaultFont(), FontSize: 10}})
+	buf := bytes.Buffer{}
+	require.NoError(t, vr.Save(&buf))
+	out := buf.String()
+	assert.Contains(t, out, "<text")
+}

--- a/chartdraw/drawing/painter_draw_test.go
+++ b/chartdraw/drawing/painter_draw_test.go
@@ -30,3 +30,20 @@ func TestDrawImageScale(t *testing.T) {
 	_, _, _, a := dst.At(1, 1).RGBA()
 	assert.Equal(t, uint32(0xffff), a)
 }
+
+func TestDrawImageFilters(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	src.Set(0, 0, color.White)
+
+	dst1 := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	DrawImage(src, dst1, NewIdentityMatrix(), draw.Over, BilinearFilter)
+	_, _, _, a := dst1.At(0, 0).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+
+	dst2 := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	DrawImage(src, dst2, NewIdentityMatrix(), draw.Over, BicubicFilter)
+	_, _, _, a = dst2.At(0, 0).RGBA()
+	assert.Equal(t, uint32(0xffff), a)
+}

--- a/chartdraw/drawing/raster_graphic_context_test.go
+++ b/chartdraw/drawing/raster_graphic_context_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-analyze/charts/chartdraw/roboto"
+	"github.com/golang/freetype/raster"
 	"github.com/golang/freetype/truetype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -226,4 +227,15 @@ func pathBounds(p *Path) (left, top, right, bottom float64) {
 		}
 	}
 	return
+}
+
+func TestNewRasterGraphicContextWithPainter(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	p := raster.NewRGBAPainter(img)
+	rgc := NewRasterGraphicContextWithPainter(img, p)
+	if rgc.painter != p {
+		t.Fatalf("painter not set")
+	}
 }

--- a/chartdraw/image_writer_test.go
+++ b/chartdraw/image_writer_test.go
@@ -1,0 +1,45 @@
+package chartdraw
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageWriterWriteAndDecode(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.White)
+
+	iw := &ImageWriter{}
+	require.NoError(t, png.Encode(iw, img))
+
+	decoded, err := iw.Image()
+	require.NoError(t, err)
+	assert.Equal(t, img.Bounds(), decoded.Bounds())
+}
+
+func TestImageWriterSetRGBA(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	iw := &ImageWriter{}
+	iw.SetRGBA(img)
+
+	got, err := iw.Image()
+	require.NoError(t, err)
+	assert.Equal(t, img, got)
+}
+
+func TestImageWriterEmpty(t *testing.T) {
+	t.Parallel()
+
+	iw := &ImageWriter{}
+	_, err := iw.Image()
+	assert.Error(t, err)
+}

--- a/chartdraw/raster_renderer_extra_test.go
+++ b/chartdraw/raster_renderer_extra_test.go
@@ -1,0 +1,42 @@
+package chartdraw
+
+import (
+	"bytes"
+	"image/png"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRasterRendererRotationAndSave(t *testing.T) {
+	t.Parallel()
+
+	rr := PNG(20, 20).(*rasterRenderer)
+	x, y := rr.getCoords(5, 5)
+	assert.Equal(t, 5, x)
+	assert.Equal(t, 5, y)
+
+	rr.SetTextRotation(math.Pi / 2)
+	x, y = rr.getCoords(5, 5)
+	assert.Zero(t, x)
+	assert.Zero(t, y)
+
+	iw := &ImageWriter{}
+	require.NoError(t, rr.Save(iw))
+	img, err := iw.Image()
+	require.NoError(t, err)
+	assert.Equal(t, 20, img.Bounds().Dx())
+}
+
+func TestRasterRendererSavePNG(t *testing.T) {
+	t.Parallel()
+
+	rr := PNG(10, 10).(*rasterRenderer)
+	buf := bytes.Buffer{}
+	require.NoError(t, rr.Save(&buf))
+	img, err := png.Decode(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	assert.Equal(t, 10, img.Bounds().Dx())
+}


### PR DESCRIPTION
## Summary
- add drawing tests to draw_test.go and remove old helpers file
- verify custom painter creation in raster context
- test image writer decode and set methods
- ensure raster renderer rotation and PNG output
- cover SVG helpers and text rotation
- exercise painter filter options

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b981827148329ad05c439be01801e