### PR TITLE
Normalize t.Run case names

### DIFF
--- a/chartdraw/drawing/curve_test.go
+++ b/chartdraw/drawing/curve_test.go
@@ -70,7 +70,7 @@ func TestTraceCubicAndArc(t *testing.T) {
 func TestSubdivideQuadAndHelpers(t *testing.T) {
 	t.Parallel()
 
-	t.Run("SubdivideQuad", func(t *testing.T) {
+	t.Run("subdivide_quad", func(t *testing.T) {
 		tests := []struct {
 			name    string
 			quad    []float64
@@ -102,7 +102,7 @@ func TestSubdivideQuadAndHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("traceWindowIndices", func(t *testing.T) {
+	t.Run("trace_window_indices", func(t *testing.T) {
 		tests := []struct {
 			idx        int
 			start, end int
@@ -121,7 +121,7 @@ func TestSubdivideQuadAndHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("traceCalcDeltas", func(t *testing.T) {
+	t.Run("trace_calc_deltas", func(t *testing.T) {
 		tests := []struct {
 			name      string
 			c         []float64
@@ -141,7 +141,7 @@ func TestSubdivideQuadAndHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("traceIsFlat", func(t *testing.T) {
+	t.Run("trace_is_flat", func(t *testing.T) {
 		tests := []struct {
 			name                 string
 			dx, dy, d, threshold float64
@@ -159,7 +159,7 @@ func TestSubdivideQuadAndHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("traceGetWindow", func(t *testing.T) {
+	t.Run("trace_get_window", func(t *testing.T) {
 		curves := []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 		tests := []struct {
 			idx    int

--- a/chartdraw/drawing/raster_graphic_context_test.go
+++ b/chartdraw/drawing/raster_graphic_context_test.go
@@ -26,7 +26,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.InDelta(t, 72.0, rgc.GetDPI(), 0.0)
 	})
 
-	t.Run("matrix operations", func(t *testing.T) {
+	t.Run("matrix_ops", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 100, 100))
@@ -49,7 +49,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.NotEqual(t, identityMatrix, transformedMatrix)
 	})
 
-	t.Run("font operations", func(t *testing.T) {
+	t.Run("font_ops", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 100, 100))
@@ -76,7 +76,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		}
 	})
 
-	t.Run("DPI operations", func(t *testing.T) {
+	t.Run("dpi_ops", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 100, 100))
@@ -91,7 +91,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.InDelta(t, 300.0, dpi, 0.001)
 	})
 
-	t.Run("save and restore", func(t *testing.T) {
+	t.Run("save_restore", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 100, 100))
@@ -129,7 +129,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.InDelta(t, expectedFontSize, restoredFontSize, 0.001)
 	})
 
-	t.Run("text operations", func(t *testing.T) {
+	t.Run("text_ops", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 100, 100))
@@ -157,7 +157,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.GreaterOrEqual(t, cursor, 0.0)
 	})
 
-	t.Run("FillRect and Clear", func(t *testing.T) {
+	t.Run("fill_rect_clear", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 2, 2))
@@ -172,7 +172,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.Equal(t, uint32(0xffff), a)
 	})
 
-	t.Run("FillRectangle", func(t *testing.T) {
+	t.Run("fill_rectangle", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 3, 3))
@@ -189,7 +189,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.Equal(t, uint32(0xffff), a)
 	})
 
-	t.Run("DrawImage", func(t *testing.T) {
+	t.Run("draw_image", func(t *testing.T) {
 		t.Parallel()
 
 		src := image.NewRGBA(image.Rect(0, 0, 1, 1))
@@ -201,7 +201,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.Equal(t, uint32(0xffff), a)
 	})
 
-	t.Run("StrokeAndFill", func(t *testing.T) {
+	t.Run("stroke_fill", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 3, 3))
@@ -235,7 +235,7 @@ func TestRasterGraphicContext(t *testing.T) {
 		assert.Equal(t, uint32(0xffff), a)
 	})
 
-	t.Run("Font Functions", func(t *testing.T) {
+	t.Run("font_funcs", func(t *testing.T) {
 		t.Parallel()
 
 		img := image.NewRGBA(image.Rect(0, 0, 20, 20))

--- a/chartdraw/drawing/transformer_test.go
+++ b/chartdraw/drawing/transformer_test.go
@@ -29,7 +29,7 @@ func (m *mockFlattener) End() {
 }
 
 func TestTransformer_MoveTo(t *testing.T) {
-	t.Run("identity transform", func(t *testing.T) {
+	t.Run("identity_transform", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &mockFlattener{}
@@ -45,7 +45,7 @@ func TestTransformer_MoveTo(t *testing.T) {
 		assert.Equal(t, []float64{20}, mock.ys)
 	})
 
-	t.Run("translation transform", func(t *testing.T) {
+	t.Run("translation_transform", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &mockFlattener{}
@@ -61,7 +61,7 @@ func TestTransformer_MoveTo(t *testing.T) {
 		assert.Equal(t, []float64{23}, mock.ys)
 	})
 
-	t.Run("scale transform", func(t *testing.T) {
+	t.Run("scale_transform", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &mockFlattener{}
@@ -81,7 +81,7 @@ func TestTransformer_MoveTo(t *testing.T) {
 func TestTransformer_LineTo(t *testing.T) {
 	t.Parallel()
 
-	t.Run("identity transform", func(t *testing.T) {
+	t.Run("identity_transform", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &mockFlattener{}
@@ -97,7 +97,7 @@ func TestTransformer_LineTo(t *testing.T) {
 		assert.Equal(t, []float64{20}, mock.ys)
 	})
 
-	t.Run("translation transform", func(t *testing.T) {
+	t.Run("translation_transform", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &mockFlattener{}
@@ -113,7 +113,7 @@ func TestTransformer_LineTo(t *testing.T) {
 		assert.Equal(t, []float64{23}, mock.ys)
 	})
 
-	t.Run("scale transform", func(t *testing.T) {
+	t.Run("scale_transform", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &mockFlattener{}

--- a/font_test.go
+++ b/font_test.go
@@ -23,7 +23,7 @@ func TestInstallGetFont(t *testing.T) {
 func TestGetPreferredFont(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nill-default", func(t *testing.T) {
+	t.Run("nil_default", func(t *testing.T) {
 		require.Equal(t, GetDefaultFont(), getPreferredFont(nil))
 	})
 }


### PR DESCRIPTION
## Summary
- standardize subtest naming with underscores
- revert painter rotation names back to dash form
- shorten save and restore test name

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6864947076248329bc0ce574eae8fdbb