### PR TITLE
test: expand candlestick chart coverage

### DIFF
--- a/mark_point_test.go
+++ b/mark_point_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,4 +49,35 @@ func TestMarkPoint(t *testing.T) {
 			assertEqualSVG(t, tt.result, data)
 		})
 	}
+
+	t.Run("pattern", func(t *testing.T) {
+		p := NewPainter(PainterOptions{
+			OutputFormat: ChartOutputSVG,
+			Width:        600,
+			Height:       400,
+		}, PainterThemeOption(GetTheme(ThemeLight)))
+
+		index := 1
+		mp := newMarkPointPainter(p.Child(PainterPaddingOption(NewBoxEqual(20))))
+		mp.add(markPointRenderOption{
+			fillColor:    ColorBlack,
+			seriesValues: []float64{1, 2, 3},
+			markpoints: []SeriesMark{{
+				Type:        SeriesMarkTypePattern,
+				PatternType: PatternEngulfingBull,
+				Index:       &index,
+				Value:       "Bull"}},
+			points: []Point{
+				{X: 10, Y: 10},
+				{X: 30, Y: 30},
+				{X: 50, Y: 50},
+			},
+		})
+
+		_, err := mp.Render()
+		require.NoError(t, err)
+		data, err := p.Bytes()
+		require.NoError(t, err)
+		assert.Greater(t, len(data), 0)
+	})
 }

--- a/series_test.go
+++ b/series_test.go
@@ -44,6 +44,21 @@ func TestSeriesLists(t *testing.T) {
 	}
 }
 
+func TestFilterSeriesListCandlestick(t *testing.T) {
+	t.Parallel()
+
+	generic := GenericSeriesList{
+		{Values: []float64{1, 2}, Type: ChartTypeCandlestick},
+		{Values: []float64{3, 4}, Type: ChartTypeLine},
+	}
+
+	filtered := filterSeriesList[[]CandlestickSeries](generic, ChartTypeCandlestick)
+	assert.Len(t, filtered, 1)
+	require.Len(t, filtered[0].Data, 2)
+	assert.InDelta(t, 1.0, filtered[0].Data[0].Open, 0)
+	assert.InDelta(t, 2.0, filtered[0].Data[1].Close, 0)
+}
+
 func TestGetSeriesMinMaxSumMaxEmpty(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- inline candlestick chart style builders within test table
- add tests for candlestick rendering via ChartOption and disallow mixed chart types
- expand coverage for mark point pattern rendering and candlestick series filtering

## Testing
- `make test` *(fails: SVG written for manual review)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ea02456883298ebc809af1b3a4f1