### PR TITLE
Clamp candlestick width ratio

### DIFF
--- a/candlestick_chart.go
+++ b/candlestick_chart.go
@@ -181,6 +181,8 @@ func (k *candlestickChart) renderChart(result *defaultRenderResult) (Box, error)
 	candleWidthRatio := opt.CandleWidth
 	if candleWidthRatio <= 0 {
 		candleWidthRatio = 0.8 // Default 80% of available space
+	} else if candleWidthRatio > 1 {
+		candleWidthRatio = 1
 	}
 	candleWidth := int(float64(width) * candleWidthRatio / float64(maxDataCount))
 	if candleWidth < 1 {

--- a/candlestick_chart_test.go
+++ b/candlestick_chart_test.go
@@ -731,6 +731,25 @@ func TestRenderCandlestickMixError(t *testing.T) {
 	assert.Contains(t, err.Error(), "candlestick can not mix other charts")
 }
 
+func TestCandlestickCandleWidthClamped(t *testing.T) {
+	t.Parallel()
+
+	opt := makeMinimalCandlestickChartOption()
+	opt.CandleWidth = 1
+	base := NewPainter(PainterOptions{OutputFormat: ChartOutputSVG, Width: 800, Height: 600})
+	require.NoError(t, base.CandlestickChart(opt))
+	expected, err := base.Bytes()
+	require.NoError(t, err)
+
+	opt.CandleWidth = 2
+	over := NewPainter(PainterOptions{OutputFormat: ChartOutputSVG, Width: 800, Height: 600})
+	require.NoError(t, over.CandlestickChart(opt))
+	actual, err := over.Bytes()
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}
+
 func validateCandlestickChartRender(t *testing.T, svgP, pngP *Painter, opt CandlestickChartOption, expectedSVG string, expectedCRC uint32) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- cap candlestick candleWidthRatio at 1
- test oversize candle widths

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b219274244832998fb46c86df7aaa2