### PR TITLE
Avoid unused label painter for candlestick charts

### DIFF
--- a/candlestick_chart.go
+++ b/candlestick_chart.go
@@ -224,24 +224,22 @@ func (k *candlestickChart) renderChart(result *defaultRenderResult) (Box, error)
 		}
 		yRange := result.yaxisRanges[series.YAxisIndex]
 
-		// Create labelPainter for this series if labels are enabled OR patterns are configured
-		var labelPainter *seriesLabelPainter
-		if flagIs(true, series.Label.Show) || series.PatternConfig != nil {
-			// If patterns are configured, create an enhanced label formatter
-			var labelToUse SeriesLabel
-			var patternMap map[int][]PatternDetectionResult
-			if series.PatternConfig != nil {
-				patternMap = scanForCandlestickPatterns(series.Data, *series.PatternConfig)
-			}
-			if len(patternMap) > 0 {
-				labelToUse = series.Label // shallow copy
-				labelToUse.LabelFormatter = createPatternAwareLabelFormatter(series, seriesIndex, opt.Theme, patternMap)
-			} else {
-				// No patterns, use original label
-				labelToUse = series.Label
-			}
+		// pre-compute patterns for this series
+		var patternMap map[int][]PatternDetectionResult
+		if series.PatternConfig != nil {
+			patternMap = scanForCandlestickPatterns(series.Data, *series.PatternConfig)
+		}
 
-			labelPainter = newSeriesLabelPainter(seriesPainter, seriesNames, labelToUse, opt.Theme, opt.Padding.Right)
+		// Create labelPainter only when labels are enabled or patterns were detected
+		var labelPainter *seriesLabelPainter
+		if flagIs(true, series.Label.Show) || len(patternMap) > 0 {
+			if len(patternMap) > 0 {
+				labelCopy := series.Label
+				labelCopy.LabelFormatter = createPatternAwareLabelFormatter(series, seriesIndex, opt.Theme, patternMap)
+				labelPainter = newSeriesLabelPainter(seriesPainter, seriesNames, labelCopy, opt.Theme, opt.Padding.Right)
+			} else {
+				labelPainter = newSeriesLabelPainter(seriesPainter, seriesNames, series.Label, opt.Theme, opt.Padding.Right)
+			}
 			rendererList = append(rendererList, labelPainter)
 		}
 		allLabelPainters[seriesIndex] = labelPainter


### PR DESCRIPTION
## Summary
- Build candlestick pattern map before considering labels
- Only allocate series label painter when labels or patterns require it
- Use original series label when no pattern-based formatting is needed
- Remove redundant candlestick label test

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b21919eb5c8329ac131facf281b005